### PR TITLE
ci(circleci): semantic-release for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,10 +230,6 @@ jobs:
                                 key: LJournal-{{ checksum "package.json" }}-{{ .Branch }}
                                 keys:
                                         - LJ-{{ checksum "package.json" }}
-            
-                        - run:
-                                name: Configure SSH for github
-                                command: ./release-github.sh       
 
                         - run:
                                 name: Install semantic release


### PR DESCRIPTION
Remove github release ssh. As the Github Token will be available in the environment variabled