### PR TITLE
fix(navbar): remove projects tab

### DIFF
--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'gatsby'
-// import "./navbar.scss";
+import "./navbar.scss";
 
 const Navbar = () => (
 	<nav className="links">
@@ -17,9 +17,9 @@ const Navbar = () => (
 			<li>
 				<Link to="/life">Life</Link>
 			</li>
-			<li>
+			{/* <li>
 				<Link to="/projects">Projects</Link>
-			</li>
+			</li> */}
 			<li>
 				<Link to="/about">About</Link>
 			</li>


### PR DESCRIPTION
Remove Projects tab as it led to a crashing Projects Page. Github API integration still fails in
production due to Github revoking API token when exposed and published to Github. This will need an alternative to load Github Projects on the blog, or remove it all together and include it as a
separate site